### PR TITLE
update syntax colors

### DIFF
--- a/styles/index.atom-text-editor.less
+++ b/styles/index.atom-text-editor.less
@@ -1,32 +1,8 @@
-// The ui-variables file is provided by base themes provided by Atom.
-//
-// See https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
-// for a full listing of what's available.
-/* @import "ui-variables"; */
+// The syntax variables are provided by the applied syntax theme
+// See https://github.com/atom/one-dark-syntax/blob/master/styles/syntax-variables.less
 
-.marko-attribute {
-    background-color: rgba(255, 255, 0, 0.05);
-    font-weight: bold;
-    // text-decoration: underline;
-}
-
-.marko-tag {
-    background-color: rgba(255, 255, 0, 0.05);
-    font-weight: bold;
-    // text-decoration: underline;
-}
-
-.marko_variable {
-    background-color: rgba(0, 255, 0, 0.1);
-    // font-weight: bold;
-}
-
+.marko-tag,
+.marko-attribute,
 .marko-placeholder {
-    background-color: rgba(0, 255, 0, 0.1);
-    // font-weight: bold;
+    color: @syntax-color-method !important;
 }
-
-// .marko_attribute {
-//     background-color: @syntax-text-color;
-//     color: @syntax-background-color;
-// }


### PR DESCRIPTION
Per #3, I've updated the highlighting to use a single syntax color from the currently applied syntax, in lieu of the background highlighting and bolding. I tried using multiple colors, but I think using one color for all marko snippets makes them easier to differentiate. I put `!important` to override specificity when marko expressions are also detected as being some other language type. Not sure what the best practice is there.

Looks good in all the default syntaxes. Shown here in Atom One Dark:
![screen shot 2016-03-19 at 2 15 21 pm](https://cloud.githubusercontent.com/assets/3595986/13901324/0f06d9ea-eddd-11e5-96a6-4df6c614e1aa.png)

